### PR TITLE
feat: settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use gnosis_vpn_lib::{address, command, socket};
 use tauri::{
-    AppHandle, Manager,
+    AppHandle, Manager, Emitter,
     menu::{Menu, MenuBuilder, MenuItem},
     tray::{TrayIconBuilder, TrayIconEvent},
 };
@@ -165,6 +165,17 @@ pub fn run() {
                                 let _ = window.show();
                                 let _ = window.set_focus();
                             }
+                        }
+                    }
+                    "settings" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            #[cfg(target_os = "macos")]
+                            {
+                                let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+                            }
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                            let _ = window.emit("navigate", "settings");
                         }
                     }
                     _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use gnosis_vpn_lib::{address, command, socket};
 use tauri::{
-    AppHandle, Manager, Emitter,
+    AppHandle, Emitter, Manager,
     menu::{Menu, MenuBuilder, MenuItem},
     tray::{TrayIconBuilder, TrayIconEvent},
 };
@@ -176,7 +176,8 @@ pub fn run() {
                             } else {
                                 #[cfg(target_os = "macos")]
                                 {
-                                    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+                                    let _ =
+                                        app.set_activation_policy(tauri::ActivationPolicy::Regular);
                                 }
                                 let _ = window.show();
                                 let _ = window.set_focus();
@@ -200,21 +201,19 @@ pub fn run() {
             // Intercept window close to hide to tray instead of exiting
             if let Some(window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
-                window.on_window_event(move |event| {
-                    match event {
-                        tauri::WindowEvent::CloseRequested { api, .. } => {
-                            api.prevent_close();
-                            if let Some(win) = app_handle.get_webview_window("main") {
-                                let _ = win.hide();
-                            }
-                            #[cfg(target_os = "macos")]
-                            {
-                                let _ = app_handle
-                                    .set_activation_policy(tauri::ActivationPolicy::Accessory);
-                            }
+                window.on_window_event(move |event| match event {
+                    tauri::WindowEvent::CloseRequested { api, .. } => {
+                        api.prevent_close();
+                        if let Some(win) = app_handle.get_webview_window("main") {
+                            let _ = win.hide();
                         }
-                        _ => {}
+                        #[cfg(target_os = "macos")]
+                        {
+                            let _ = app_handle
+                                .set_activation_policy(tauri::ActivationPolicy::Accessory);
+                        }
                     }
+                    _ => {}
                 });
             }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,14 +11,12 @@ use platform::{Platform, PlatformInterface};
 use serde::Serialize;
 use tauri_plugin_store::StoreExt;
 
-#[derive(Clone, Debug, Serialize)]
-#[derive(Default)]
+#[derive(Clone, Debug, Serialize, Default)]
 struct AppSettings {
     preferred_location: Option<String>,
     connect_on_startup: bool,
     start_minimized: bool,
 }
-
 
 #[tauri::command]
 fn status() -> Result<command::StatusResponse, String> {
@@ -90,10 +88,11 @@ fn toggle_main_window_visibility(app: &AppHandle) {
 
 fn handle_tray_event(app: &AppHandle, event: TrayIconEvent) {
     if let TrayIconEvent::Click {
-            button: tauri::tray::MouseButton::Left,
-            button_state: tauri::tray::MouseButtonState::Up,
-            ..
-        } = event {
+        button: tauri::tray::MouseButton::Left,
+        button_state: tauri::tray::MouseButtonState::Up,
+        ..
+    } = event
+    {
         toggle_main_window_visibility(app);
     }
 }
@@ -192,13 +191,15 @@ pub fn run() {
             if let Some(window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
                 let window_clone = window.clone();
-                window.on_window_event(move |event| if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    let _ = window_clone.hide();
-                    #[cfg(target_os = "macos")]
-                    {
-                        let _ = app_handle
-                            .set_activation_policy(tauri::ActivationPolicy::Accessory);
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = window_clone.hide();
+                        #[cfg(target_os = "macos")]
+                        {
+                            let _ = app_handle
+                                .set_activation_policy(tauri::ActivationPolicy::Accessory);
+                        }
                     }
                 });
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,8 @@ fn create_tray_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         MenuItem::with_id(app, "status", "Status: Disconnected", false, None::<&str>)?;
     let show_item = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
     let settings_item = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
+    let logs_item = MenuItem::with_id(app, "logs", "Logs", true, None::<&str>)?;
+    let usage_item = MenuItem::with_id(app, "usage", "Usage", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
     MenuBuilder::new(app)
@@ -73,6 +75,8 @@ fn create_tray_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         .separator()
         .item(&show_item)
         .item(&settings_item)
+        .item(&logs_item)
+        .item(&usage_item)
         .item(&quit_item)
         .build()
 }
@@ -99,6 +103,18 @@ fn handle_tray_event(app: &AppHandle, event: TrayIconEvent) {
             }
         }
         _ => {}
+    }
+}
+
+fn show_and_navigate(app: &AppHandle, target: &str) {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "macos")]
+        {
+            let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+        }
+        let _ = window.show();
+        let _ = window.set_focus();
+        let _ = window.emit("navigate", target);
     }
 }
 
@@ -167,17 +183,9 @@ pub fn run() {
                             }
                         }
                     }
-                    "settings" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            #[cfg(target_os = "macos")]
-                            {
-                                let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
-                            }
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                            let _ = window.emit("navigate", "settings");
-                        }
-                    }
+                    "settings" => show_and_navigate(app, "settings"),
+                    "logs" => show_and_navigate(app, "logs"),
+                    "usage" => show_and_navigate(app, "usage"),
                     _ => {}
                 })
                 .on_tray_icon_event(|tray, event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "Gnosis VPN",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "visible": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,10 +36,14 @@ function App() {
 
       appActions.startStatusPolling(2000);
 
-      const valid = ['main', 'settings', 'logs', 'usage'] as const;
+      const validScreens = ['main', 'settings', 'logs', 'usage'] as const;
+      type ValidScreen = (typeof validScreens)[number];
+      const isValidScreen = (s: string): s is ValidScreen =>
+        (validScreens as readonly string[]).includes(s);
+
       unlistenNavigate = await listen<string>('navigate', ({ payload }) => {
-        if ((valid as readonly string[]).includes(payload)) {
-          appActions.setScreen(payload as (typeof valid)[number]);
+        if (isValidScreen(payload)) {
+          appActions.setScreen(payload);
         }
       });
     })();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Settings from './screens/Settings';
 import { useAppStore } from './stores/appStore';
 import Usage from './screens/Usage';
 import { onCleanup, onMount } from 'solid-js';
+import { useSettingsStore } from './stores/settingsStore';
 
 const screens = {
   main: MainScreen,
@@ -17,10 +18,20 @@ const screens = {
 
 function App() {
   const [appState, appActions] = useAppStore();
+  const [settings] = useSettingsStore();
 
   onMount(() => {
     void (async () => {
       await appActions.refreshStatus();
+
+      if (
+        settings.connectOnStartup &&
+        appState.connectionStatus === 'Disconnected' &&
+        appState.availableDestinations.length > 0
+      ) {
+        await appActions.connect();
+      }
+
       appActions.startStatusPolling(2000);
     })();
   });

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -13,8 +13,20 @@ export default function Settings() {
     <SecondaryScreen>
       <div class="space-y-4 p-6">
         <div class="space-y-2">
-          <Toggle label="Connect on application startup" />
-          <Toggle label="Start application minimized" />
+          <Toggle
+            label="Connect on application startup"
+            checked={settings.connectOnStartup}
+            onChange={e =>
+              void settingsActions.setConnectOnStartup(e.currentTarget.checked)
+            }
+          />
+          <Toggle
+            label="Start application minimized"
+            checked={settings.startMinimized}
+            onChange={e =>
+              void settingsActions.setStartMinimized(e.currentTarget.checked)
+            }
+          />
 
           <label class="flex items-center justify-between gap-2">
             Preferred server location

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -157,7 +157,7 @@ export function createAppStore(): AppStoreTuple {
           );
 
         appendContentIfNew(
-          `Connect target: ${targetAddress ?? 'none'} (${selectionReason})`
+          `Connecting to ${selectionReason}: ${targetAddress ?? 'none'}`
         );
 
         if (targetAddress) {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -10,7 +10,7 @@ export interface SettingsState {
 const DEFAULT_SETTINGS: SettingsState = {
   preferredLocation: null,
   connectOnStartup: false,
-  startMinimized: true,
+  startMinimized: false,
 };
 
 type SettingsActions = {


### PR DESCRIPTION
Implemented settings:
- connect on app startup
- start app minimized
&
- hide window on close (don't exit)

Tray icon menu:
- click on item opens relevant window (closes https://github.com/gnosis/gnosis_vpn-app/issues/23)

Fixes #17
Fixes #23