### PR TITLE
fix: Fix trigger workflow to gnosis_vpn project

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,6 +168,5 @@ jobs:
             {
               "public_release": "false",
               "client_version": "latest",
-              "app_version": "${{ steps.bump.outputs.current_version }}",
-              "sign": "true",
+              "app_version": "${{ steps.bump.outputs.current_version }}"
             }


### PR DESCRIPTION
Fixes the last step of the release workflow while tries to trigger the release workflow on repository `gnosis_vpn`