### PR TITLE
  fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -20,7 +20,8 @@ on:
 jobs:
   binary:
     permissions:
-      contents: write
+      contents: read
+      pull-requests: read
     if: >-
       github.event_name != 'pull_request' || github.event.pull_request.merged == true || contains(github.event.pull_request.labels.*.name, format('binary:{0}', inputs.architecture))
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
       - labeled
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.ref }}-build

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
 permissions:
-  contents: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: merge


### PR DESCRIPTION
  Resolves CodeQL alerts #7-#10 by adding least-privilege permissions blocks                                                     to build.yml, build-binaries.yaml, and merge.yaml.