### PR TITLE
fix: Adapt to the new release-version-v3 parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     name: Checks
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - name: Checkout repository
+      - name: Run checks
         uses: hoprnet/hopr-workflows/actions/nix-action@nix-action-v1
         with:
           source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,6 @@ jobs:
           source_branch: ${{ github.ref_name }}
           file: src-tauri/Cargo.toml
           release_type: ${{ inputs.release_type }}
-          package_name: gnosis_vpn-app
           cachix_cache_name: gnosis-vpn-app
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
@@ -63,7 +62,7 @@ jobs:
           zulip_channel: GnosisVPN
           zulip_topic: Releases
           gcp_service_account: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
-          gcp_project: gnosisvpn-production
+          gcp_artifact_package: gnosis_vpn-app
           github_token: ${{ secrets.BOT_TOKEN }}
       - name: Bump Package.json
         id: bump


### PR DESCRIPTION
The `release-version-v3` make some breaking changes in the input parameters which were not applied