### PR TITLE
fix: Replaces the GitHub token used in workflows

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -45,6 +45,6 @@ jobs:
       - name: Trigger snapshot build
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           repository: gnosis/gnosis_vpn
           event-type: snapshot_build


### PR DESCRIPTION
The secret `GNOSIS_GITHUB_WORKFLOW_TOKEN` no longer exist.  it should be used `BOT_TOKEN`