### PR TITLE
fix(renovate): enable nix flake.lock updates and fix prCreation deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,20 @@ Run linting locally via:
 ```sh
 nix develop --command deno lint --fix
 ```
+
+## Dependency Updates
+
+Renovate runs on Renovate's `schedule:earlyMondays` preset with a 14-day minimum
+release age, so most PRs appear early Monday morning and only for packages that
+have been released for at least two weeks.
+
+Updates are grouped by ecosystem:
+
+| Group               | What it covers                                        | Notes                                                                                                 |
+| ------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `nix flake updates` | `flake.lock` inputs (nixpkgs, crane, rust-overlay, …) | digest/pinDigest updates; `pinDigests` disabled for the `nix` manager since nix pins via `flake.lock` |
+| `github-actions`    | `.github/workflows` action refs                       | digest-pinned                                                                                         |
+| _(individual PRs)_  | npm/deno packages and Cargo crates                    | one PR per package                                                                                    |
+
+`prCreation: immediate` is intentional — CI only triggers on pull request
+events, so waiting for branch checks would deadlock.

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "schedule:earlyMondays"],
   "pinDigests": true,
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
   "vulnerabilityAlerts": { "enabled": true },
@@ -16,8 +16,8 @@
     },
     {
       "matchManagers": ["nix"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "nix flake updates"
+      "groupName": "nix flake updates",
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
- Dropped matchUpdateTypes from the nix rule — nix flake inputs tracking branches only generate digest/pinDigest updates, never minor/patch, so the old filter silently suppressed all flake.lock updates.
- Added pinDigests: false to the nix rule — renovate cannot do the initial branch-name → commit-hash transformation in flake.nix; the replacement is always a no-op and errors out.
- Changed prCreation from not-pending to immediate — CI only triggers on pull request events, so waiting for branch checks would deadlock.
- Added Dependency Updates section to README.