### PR TITLE
feat: add country flag display to exit node list and main screen

### DIFF
--- a/.claude/skills/run-gnosis-vpn-app/SKILL.md
+++ b/.claude/skills/run-gnosis-vpn-app/SKILL.md
@@ -52,9 +52,13 @@ source:
   screen; `funding_issues: ["SafeLowOnFunds"]` shows the low-balance banner
   (`"Unfunded"` etc. → "empty" variant; see `FundingIssueSchema` in
   `src/services/vpnService.ts`).
+- `destination.meta.flag` — optional ISO 3166-1 alpha-2 code (e.g. `"SE"`,
+  `"BR"`) placed inside each destination's `meta` object; when present and
+  `settings.flagDisplay` is not `"none"`, the UI renders the country flag next to
+  the destination label.
 - `settings` — seeds the shim's `get_settings` snapshot (camelCase keys as in
   `SettingsSchema` in `src/stores/settingsStore.ts`), e.g.
-  `"settings": { "exitNodeSortOrder": "alpha", "showDetailedMetrics": true }`.
+  `"settings": { "exitNodeSortOrder": "alpha", "showDetailedMetrics": true, "flagDisplay": "color" }`.
   Unset keys fall back to the app's defaults; `update_settings` merges the patch
   in-memory and fires `settings-changed`, so toggles behave realistically.
 - `windowLabel: "settings"` renders the settings window instead (use

--- a/.claude/skills/run-gnosis-vpn-app/SKILL.md
+++ b/.claude/skills/run-gnosis-vpn-app/SKILL.md
@@ -54,8 +54,8 @@ source:
   `src/services/vpnService.ts`).
 - `destination.meta.flag` — optional ISO 3166-1 alpha-2 code (e.g. `"SE"`,
   `"BR"`) placed inside each destination's `meta` object; when present and
-  `settings.flagDisplay` is not `"none"`, the UI renders the country flag next to
-  the destination label.
+  `settings.flagDisplay` is not `"none"`, the UI renders the country flag next
+  to the destination label.
 - `settings` — seeds the shim's `get_settings` snapshot (camelCase keys as in
   `SettingsSchema` in `src/stores/settingsStore.ts`), e.g.
   `"settings": { "exitNodeSortOrder": "alpha", "showDetailedMetrics": true, "flagDisplay": "color" }`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ Vite
 - `public/` - Static assets
 - Config: `vite.config.ts`, `tauri.conf.json`, `flake.nix` (Nix dev environment)
 
-**Key Dependencies**: `@tauri-apps/api`, `solid-js`, `tailwindcss`, Deno (task
-runner)
+**Key Dependencies**: `@tauri-apps/api`, `solid-js`, `tailwindcss`, `flag-icons`
+(SVG country flags), Deno (task runner)
 
 ## Code Style & Conventions
 

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
     "npm:@types/qrcode@^1.5.6": "1.5.6",
     "npm:dompurify@^3.4.5": "3.4.5",
     "npm:eslint@^10.4.0": "10.4.0",
+    "npm:flag-icons@^7.5.0": "7.5.0",
     "npm:marked@^18.0.4": "18.0.4",
     "npm:prettier@^3.8.4": "3.9.4",
     "npm:qrcode@^1.5.4": "1.5.4",
@@ -961,6 +962,9 @@
         "path-exists"
       ]
     },
+    "flag-icons@7.5.0": {
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg=="
+    },
     "flat-cache@4.0.1": {
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dependencies": [
@@ -1564,6 +1568,7 @@
         "npm:@types/qrcode@^1.5.6",
         "npm:dompurify@^3.4.5",
         "npm:eslint@^10.4.0",
+        "npm:flag-icons@^7.5.0",
         "npm:marked@^18.0.4",
         "npm:prettier@^3.8.4",
         "npm:qrcode@^1.5.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/plugin-dialog": "2.7.1",
     "@types/qrcode": "^1.5.6",
     "dompurify": "^3.4.5",
+    "flag-icons": "^7.5.0",
     "qrcode": "^1.5.4",
     "solid-js": "^1.9.13",
     "@tauri-apps/api": "^2.11.0",

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -23,9 +23,10 @@ pub struct Settings {
     pub channel: Option<UpdateChannel>,
     pub dismissed_update_version: Option<String>,
     pub show_detailed_metrics: bool,
+    pub flag_display: FlagDisplay,
 }
 
-// Both enums serialize as plain strings (not tagged objects) to stay
+// All enums serialize as plain strings (not tagged objects) to stay
 // wire-compatible with the persisted settings.json and the TS union types.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -33,6 +34,15 @@ pub enum SortOrder {
     #[default]
     Latency,
     Alpha,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FlagDisplay {
+    None,
+    Mono,
+    #[default]
+    Color,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -67,6 +77,8 @@ pub struct SettingsPatch {
     pub dismissed_update_version: Option<Option<String>>,
     #[serde(default)]
     pub show_detailed_metrics: Option<bool>,
+    #[serde(default)]
+    pub flag_display: Option<FlagDisplay>,
 }
 
 fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
@@ -108,6 +120,9 @@ impl Settings {
         }
         if let Some(v) = patch.show_detailed_metrics {
             self.show_detailed_metrics = v;
+        }
+        if let Some(v) = patch.flag_display {
+            self.flag_display = v;
         }
     }
 }

--- a/src-tauri/tests/serialize_fixtures.rs
+++ b/src-tauri/tests/serialize_fixtures.rs
@@ -1,4 +1,4 @@
-use gnosis_vpn_app_lib::settings::{Settings, SortOrder, UpdateChannel};
+use gnosis_vpn_app_lib::settings::{FlagDisplay, Settings, SortOrder, UpdateChannel};
 use gnosis_vpn_app_lib::types;
 use gnosis_vpn_lib::balance::{
     Balance, BalanceRecommendation, Balances, Capacity, CapacityAllocator, FundingIssue, WxHOPR,
@@ -424,5 +424,6 @@ fn full_settings() -> Settings {
         channel: Some(UpdateChannel::Snapshot),
         dismissed_update_version: Some("0.28.0".to_string()),
         show_detailed_metrics: true,
+        flag_display: FlagDisplay::Mono,
     }
 }

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -11,7 +11,9 @@ export default function Flag(props: { code: string }) {
   return (
     <Show when={visible()}>
       <span
-        class={`fi fi-${props.code} rounded-sm shrink-0${grayscale() ? " grayscale" : ""}`}
+        class={`fi fi-${props.code} rounded-sm shrink-0${
+          grayscale() ? " grayscale" : ""
+        }`}
         aria-hidden="true"
       />
     </Show>

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -11,7 +11,7 @@ export default function Flag(props: { code: string }) {
   return (
     <Show when={visible()}>
       <span
-        class={`fi fi-${props.code.toLowerCase()} rounded-sm shrink-0`}
+        class={`fi fi-${props.code} rounded-sm shrink-0`}
         style={grayscale() ? { filter: "grayscale(1)" } : {}}
         aria-hidden="true"
       />

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -13,7 +13,7 @@ export default function Flag(props: { code: string }) {
       <span
         class={`fi fi-${props.code.toLowerCase()} rounded-sm shrink-0`}
         style={grayscale() ? { filter: "grayscale(1)" } : {}}
-        aria-hidden
+        aria-hidden="true"
       />
     </Show>
   );

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -11,8 +11,7 @@ export default function Flag(props: { code: string }) {
   return (
     <Show when={visible()}>
       <span
-        class={`fi fi-${props.code} rounded-sm shrink-0`}
-        style={grayscale() ? { filter: "grayscale(1)" } : {}}
+        class={`fi fi-${props.code} rounded-sm shrink-0${grayscale() ? " grayscale" : ""}`}
         aria-hidden="true"
       />
     </Show>

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -1,0 +1,20 @@
+import { Show } from "solid-js";
+import { useSettingsStore } from "@src/stores/settingsStore.ts";
+
+export default function Flag(props: { code: string }) {
+  const [settings] = useSettingsStore();
+
+  const visible = () =>
+    props.code.length > 0 && settings.flagDisplay !== "none";
+  const grayscale = () => settings.flagDisplay === "mono";
+
+  return (
+    <Show when={visible()}>
+      <span
+        class={`fi fi-${props.code.toLowerCase()} rounded-sm shrink-0`}
+        style={grayscale() ? { filter: "grayscale(1)" } : {}}
+        aria-hidden
+      />
+    </Show>
+  );
+}

--- a/src/components/exitNode/ExitNode.tsx
+++ b/src/components/exitNode/ExitNode.tsx
@@ -63,9 +63,7 @@ export default function ExitNode() {
           >
             {(selectedId) => {
               const dest = () =>
-                appState.availableDestinations.find(
-                  (d) => d.id === selectedId(),
-                );
+                appState.destinations[selectedId()]?.destination;
               return (
                 <span class="flex items-center gap-1.5 text-sm font-medium text-text-primary min-w-0">
                   <Flag code={dest()?.meta.flag ?? ""} />

--- a/src/components/exitNode/ExitNode.tsx
+++ b/src/components/exitNode/ExitNode.tsx
@@ -8,6 +8,7 @@ import { createMemo, createSignal, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { useSettingsStore } from "../../stores/settingsStore.ts";
 import ExitNodeList from "./ExitNodeList.tsx";
+import Flag from "../Flag.tsx";
 
 export default function ExitNode() {
   const [appState] = useAppStore();
@@ -51,22 +52,32 @@ export default function ExitNode() {
                     <span class="text-sm font-medium text-text-primary">
                       Auto
                     </span>
-                    <span class="text-xs text-text-secondary break-all">
-                      {destinationLabel(dest())}
+                    <span class="flex items-center gap-1.5 text-xs text-text-secondary min-w-0">
+                      <Flag code={dest().meta.flag ?? ""} />
+                      <span class="break-all">{destinationLabel(dest())}</span>
                     </span>
                   </span>
                 )}
               </Show>
             }
           >
-            {(selectedId) => (
-              <span class="text-sm font-medium text-text-primary break-all">
-                {destinationLabelById(
-                  selectedId(),
-                  appState.availableDestinations,
-                )}
-              </span>
-            )}
+            {(selectedId) => {
+              const dest = () =>
+                appState.availableDestinations.find(
+                  (d) => d.id === selectedId(),
+                );
+              return (
+                <span class="flex items-center gap-1.5 text-sm font-medium text-text-primary min-w-0">
+                  <Flag code={dest()?.meta.flag ?? ""} />
+                  <span class="break-all">
+                    {destinationLabelById(
+                      selectedId(),
+                      appState.availableDestinations,
+                    )}
+                  </span>
+                </span>
+              );
+            }}
           </Show>
         </div>
         <svg

--- a/src/components/exitNode/ExitNodeCard.tsx
+++ b/src/components/exitNode/ExitNodeCard.tsx
@@ -121,7 +121,7 @@ export default function ExitNodeCard(props: {
           <div
             class={`absolute inset-y-0 left-0 w-1 ${color()}`}
             classList={{ "animate-pulse": isConnecting() || isReconnecting() }}
-            aria-hidden
+            aria-hidden="true"
           />
         )}
       </Show>

--- a/src/components/exitNode/ExitNodeCard.tsx
+++ b/src/components/exitNode/ExitNodeCard.tsx
@@ -21,6 +21,7 @@ import {
 import HopsIcon from "./HopsIcon.tsx";
 import Stat from "./Stat.tsx";
 import Tag from "../common/Tag.tsx";
+import Flag from "../Flag.tsx";
 
 export default function ExitNodeCard(props: {
   destinationState: () => DestinationState;
@@ -126,8 +127,11 @@ export default function ExitNodeCard(props: {
       </Show>
       <div class="min-w-0 flex-1 px-4 py-3">
         <div class="flex flex-wrap items-start justify-between gap-1.5 mb-1">
-          <span class="font-semibold text-sm text-text-primary break-all">
-            {destinationLabel(props.destinationState().destination)}
+          <span class="flex items-center gap-1.5 font-semibold text-sm text-text-primary min-w-0">
+            <Flag code={props.destinationState().destination.meta.flag ?? ""} />
+            <span class="break-all">
+              {destinationLabel(props.destinationState().destination)}
+            </span>
           </span>
           <Show when={route() && hopCount() !== 1}>
             <Tag>

--- a/src/components/exitNode/ExitNodeList.tsx
+++ b/src/components/exitNode/ExitNodeList.tsx
@@ -247,7 +247,7 @@ export default function ExitNodeList(props: { onClose: () => void }) {
             <Show when={appState.selectedId === null}>
               <div
                 class="absolute inset-y-0 left-0 w-1 bg-text-muted"
-                aria-hidden
+                aria-hidden="true"
               />
             </Show>
             <div class="flex flex-col">

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "flag-icons/css/flag-icons.min.css";
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* Local fonts */

--- a/src/screens/settings/Settings.tsx
+++ b/src/screens/settings/Settings.tsx
@@ -72,7 +72,7 @@ export default function Settings() {
           options={FLAG_DISPLAY_OPTIONS}
           value={FLAG_DISPLAY_OPTIONS.find(
             (o) => o.id === settings.flagDisplay,
-          ) ?? FLAG_DISPLAY_OPTIONS[2]}
+          ) ?? FLAG_DISPLAY_OPTIONS.find((o) => o.id === "color")!}
           onChange={(o) => void settingsActions.setFlagDisplay(o.id)}
           size="sm"
           itemToString={(o) => o.label}

--- a/src/screens/settings/Settings.tsx
+++ b/src/screens/settings/Settings.tsx
@@ -72,7 +72,7 @@ export default function Settings() {
           options={FLAG_DISPLAY_OPTIONS}
           value={FLAG_DISPLAY_OPTIONS.find(
             (o) => o.id === settings.flagDisplay,
-          )!}
+          ) ?? FLAG_DISPLAY_OPTIONS[2]}
           onChange={(o) => void settingsActions.setFlagDisplay(o.id)}
           size="sm"
           itemToString={(o) => o.label}

--- a/src/screens/settings/Settings.tsx
+++ b/src/screens/settings/Settings.tsx
@@ -1,12 +1,21 @@
 import { Dropdown } from "../../components/common/Dropdown.tsx";
 import Toggle from "@src/components/common/Toggle.tsx";
 import { useAppStore } from "@src/stores/appStore.ts";
-import { useSettingsStore } from "@src/stores/settingsStore.ts";
+import {
+  type FlagDisplay,
+  useSettingsStore,
+} from "@src/stores/settingsStore.ts";
 import {
   destinationLabel,
   destinationLabelById,
 } from "@src/utils/destinations.ts";
 import { Show } from "solid-js";
+
+const FLAG_DISPLAY_OPTIONS: { id: FlagDisplay; label: string }[] = [
+  { id: "none", label: "Off" },
+  { id: "mono", label: "Monochromatic" },
+  { id: "color", label: "Colored" },
+];
 
 export default function Settings() {
   const [appState] = useAppStore();
@@ -57,6 +66,18 @@ export default function Settings() {
         onChange={(e) =>
           void settingsActions.setStartMinimized(e.currentTarget.checked)}
       />
+      <label class="flex items-center justify-between gap-2 text-text-primary">
+        Exit node flags
+        <Dropdown
+          options={FLAG_DISPLAY_OPTIONS}
+          value={FLAG_DISPLAY_OPTIONS.find(
+            (o) => o.id === settings.flagDisplay,
+          )!}
+          onChange={(o) => void settingsActions.setFlagDisplay(o.id)}
+          size="sm"
+          itemToString={(o) => o.label}
+        />
+      </label>
       <div class="grow" />
     </div>
   );

--- a/src/services/fixtures/settings_default.json
+++ b/src/services/fixtures/settings_default.json
@@ -8,5 +8,6 @@
   "updateManifest": null,
   "channel": null,
   "dismissedUpdateVersion": null,
-  "showDetailedMetrics": false
+  "showDetailedMetrics": false,
+  "flagDisplay": "color"
 }

--- a/src/services/fixtures/settings_full.json
+++ b/src/services/fixtures/settings_full.json
@@ -25,5 +25,6 @@
   },
   "channel": "snapshot",
   "dismissedUpdateVersion": "0.28.0",
-  "showDetailedMetrics": true
+  "showDetailedMetrics": true,
+  "flagDisplay": "mono"
 }

--- a/src/services/vpnService.ts
+++ b/src/services/vpnService.ts
@@ -56,9 +56,21 @@ export const DisconnectingInfoSchema = z.object({
 });
 export type DisconnectingInfo = z.infer<typeof DisconnectingInfoSchema>;
 
+// ISO 3166-1 alpha-2: exactly two ASCII letters, normalized to lowercase.
+// .catch(undefined) silently drops any value that doesn't match so garbage
+// from the server never reaches the CSS class string in Flag.tsx.
+const FlagCodeSchema = z
+  .string()
+  .regex(/^[a-zA-Z]{2}$/)
+  .transform((s) => s.toLowerCase())
+  .optional()
+  .catch(undefined);
+
 export const DestinationSchema = z.object({
   id: z.string(),
-  meta: z.object({ location: z.string() }).catchall(z.string()),
+  meta: z
+    .object({ location: z.string(), flag: FlagCodeSchema })
+    .catchall(z.string()),
   address: z.string(),
   routing: z.number(),
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -44,6 +44,9 @@ export type UpdateManifest = z.infer<typeof UpdateManifestSchema>;
 export const UpdateChannelSchema = z.enum(["stable", "snapshot"]);
 export type UpdateChannel = z.infer<typeof UpdateChannelSchema>;
 
+export const FlagDisplaySchema = z.enum(["none", "mono", "color"]);
+export type FlagDisplay = z.infer<typeof FlagDisplaySchema>;
+
 export const SettingsSchema = z.object({
   preferredLocation: z.string().nullable(),
   connectOnStartup: z.boolean(),
@@ -55,6 +58,7 @@ export const SettingsSchema = z.object({
   channel: UpdateChannelSchema.nullable(),
   dismissedUpdateVersion: z.string().nullable(),
   showDetailedMetrics: z.boolean(),
+  flagDisplay: FlagDisplaySchema,
 });
 export type SettingsState = z.infer<typeof SettingsSchema>;
 
@@ -70,6 +74,7 @@ const DEFAULT_SETTINGS: SettingsState = {
   channel: null,
   dismissedUpdateVersion: null,
   showDetailedMetrics: false,
+  flagDisplay: "color",
 };
 
 type SettingsActions = {
@@ -86,6 +91,7 @@ type SettingsActions = {
   setChannel: (channel: UpdateChannel) => Promise<void>;
   setDismissedUpdateVersion: (version: string | null) => Promise<void>;
   setShowDetailedMetrics: (show: boolean) => Promise<void>;
+  setFlagDisplay: (display: FlagDisplay) => Promise<void>;
 };
 
 type SettingsStoreTuple = readonly [
@@ -164,6 +170,7 @@ export function createSettingsStore(): SettingsStoreTuple {
     setDismissedUpdateVersion: (version) =>
       patch({ dismissedUpdateVersion: version }),
     setShowDetailedMetrics: (show) => patch({ showDetailedMetrics: show }),
+    setFlagDisplay: (display) => patch({ flagDisplay: display }),
   } as const;
 
   const dispose = () => {


### PR DESCRIPTION
Adds optional `flag` field (ISO 3166-1 alpha-2) to destination meta, rendered via flag-icons in three modes: off / monochromatic / colored. The active mode is a new persisted setting (flagDisplay, default: color).