### PR TITLE
feat: lengthen sync progress phases and extend recovery watchdog to 5 minutes

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -732,8 +732,8 @@
       "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "bin": true
     },
-    "brace-expansion@5.0.7": {
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+    "brace-expansion@5.0.8": {
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dependencies": [
         "balanced-match"
       ]
@@ -1251,8 +1251,8 @@
     "pngjs@5.0.0": {
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
-    "postcss@8.5.15": {
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+    "postcss@8.5.18": {
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dependencies": [
         "nanoid",
         "picocolors",

--- a/src/screens/settings/Updates.tsx
+++ b/src/screens/settings/Updates.tsx
@@ -341,7 +341,7 @@ export default function Updates() {
         options={CHANNEL_OPTIONS}
         value={effectiveChannel()}
         onChange={(ch) => void settingsActions.setChannel(ch)}
-        disabled={true} //installedChannel() === "stable"}
+        disabled //installedChannel() === "stable"}
         // tooltipSwitcher="When on Stable, you can't switch to Snapshot"
       />
       <div class="grow" />

--- a/src/screens/settings/Updates.tsx
+++ b/src/screens/settings/Updates.tsx
@@ -92,10 +92,10 @@ export default function Updates() {
     appState.serviceInfo?.package_version ?? null
   );
 
-  const installedChannel = createMemo<UpdateChannel | null>(() => {
-    const ver = packageVersion();
-    return ver ? detectChannel(ver) : null;
-  });
+  // const installedChannel = createMemo<UpdateChannel | null>(() => {
+  //   const ver = packageVersion();
+  //   return ver ? detectChannel(ver) : null;
+  // });
 
   const effectiveChannel = createMemo<UpdateChannel>(() => {
     if (settings.channel) return settings.channel;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -118,9 +118,9 @@ function initialState(): AppState {
 // floor/ceiling are % values; durationMs is the expected phase duration.
 // Adjust durationMs when real-world timing data is available.
 const SYNC_PHASES = [
-  { floor: 0, ceiling: 30, durationMs: 30_000 }, // DeployingSafe
-  { floor: 30, ceiling: 50, durationMs: 20_000 }, // Warmup
-  { floor: 50, ceiling: 100, durationMs: 50_000 }, // Channels/peers delay
+  { floor: 0, ceiling: 25, durationMs: 30_000 }, // DeployingSafe
+  { floor: 25, ceiling: 40, durationMs: 30_000 }, // Warmup
+  { floor: 40, ceiling: 100, durationMs: 180_000 }, // Channels/peers delay
 ] as const;
 type SyncPhaseIndex = 0 | 1 | 2;
 
@@ -609,7 +609,7 @@ export function useAppStore(): AppStoreTuple {
   return appStore;
 }
 
-const MAXIMUM_DELAY_TIME = 120 * 1000; // 2 minutes
+const MAXIMUM_DELAY_TIME = 5 * 60 * 1000; // 5 minutes
 let initialDelay:
   | { delayingSince: number }
   | { neverRan: true }


### PR DESCRIPTION
The sync is a lot longer now, we need longer screens displaying it 